### PR TITLE
Clean up incorrect links and update branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,9 +66,11 @@
 
   <div class="wrap">
     <header role="banner" aria-labelledby="site-title">
-      <img src="/assets/logo.svg" width="600" height="128" alt="THINK TWICE wordmark" />
-      <h1 id="site-title" class="visually-hidden">THINK TWICE — Official Link Hub</h1>
-      <p class="hook">Florida metal core. <strong>New singles out now.</strong></p>
+      <div class="band-header">
+        <img src="/assets/logo.svg" width="220" height="64" alt="THINK TWICE logo" class="band-logo" />
+        <h1 id="site-title" class="band-title">THINK TWICE</h1>
+      </div>
+      <p class="hook">Florida Metalcore. <strong>New singles out now.</strong></p>
     </header>
 
     <main id="main" role="main">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="x-ua-compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>THINK TWICE — Official Link Hub</title>
-  <meta name="description" content="Florida metalcore. New singles out now. Stream Think Twice on Spotify, Apple Music, and more." />
+  <meta name="description" content="Florida metal core. New singles out now." />
   <link rel="canonical" href="https://thinktwice.verdantmission.org/" />
 
   <!-- Icons -->
@@ -15,7 +15,7 @@
 
   <!-- Open Graph -->
   <meta property="og:title" content="THINK TWICE — Official Link Hub" />
-  <meta property="og:description" content="Florida metalcore. New singles out now." />
+  <meta property="og:description" content="Florida metal core. New singles out now." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thinktwice.verdantmission.org/" />
   <meta property="og:image" content="https://thinktwice.verdantmission.org/assets/logo.svg" />
@@ -25,7 +25,7 @@
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="THINK TWICE — Official Link Hub" />
-  <meta name="twitter:description" content="Florida metalcore. New singles out now." />
+  <meta name="twitter:description" content="Florida metal core. New singles out now." />
   <meta name="twitter:image" content="https://thinktwice.verdantmission.org/assets/logo.svg" />
 
   <!-- Theming & color-scheme -->
@@ -68,7 +68,7 @@
     <header role="banner" aria-labelledby="site-title">
       <img src="/assets/logo.svg" width="600" height="128" alt="THINK TWICE wordmark" />
       <h1 id="site-title" class="visually-hidden">THINK TWICE — Official Link Hub</h1>
-      <p class="hook">Florida metalcore. <strong>New singles out now.</strong></p>
+      <p class="hook">Florida metal core. <strong>New singles out now.</strong></p>
     </header>
 
     <main id="main" role="main">
@@ -76,15 +76,6 @@
         <h2 class="section-title">Featured releases</h2>
         <ul id="featured" class="list" aria-live="polite"></ul>
       </nav>
-
-      <section class="embed" aria-label="Spotify artist embed">
-        <iframe
-          title="Spotify — Think Twice (Artist)"
-          loading="lazy"
-          src="https://open.spotify.com/embed/artist/0U2ZIIYIMFChatxKoQJdTU"
-          allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture">
-        </iframe>
-      </section>
 
       <nav aria-label="Streaming and socials">
         <h2 class="section-title">Streaming / socials</h2>
@@ -166,15 +157,10 @@
       // Minimal fallback if links.json fails
       featuredEl.innerHTML = `
         <li><a class="btn" href="https://found.ee/RECOVERY1" target="_blank" rel="noopener" aria-label="RECOVERY — Stream — found.ee">${ICONS.link}<span class="btn-text"><span class="btn-title">RECOVERY — Stream</span><span class="btn-meta">found.ee</span></span></a></li>
-        <li><a class="btn" href="https://found.ee/time-10" target="_blank" rel="noopener" aria-label="TIME — Stream — found.ee">${ICONS.link}<span class="btn-text"><span class="btn-title">TIME — Stream</span><span class="btn-meta">found.ee</span></span></a></li>
       `;
       linksEl.innerHTML = `
-        <li><a class="btn" href="https://open.spotify.com/artist/0U2ZIIYIMFChatxKoQJdTU" target="_blank" rel="noopener" aria-label="Spotify (Artist) — Spotify">${ICONS.spotify}<span class="btn-text"><span class="btn-title">Spotify (Artist)</span><span class="btn-meta">Spotify</span></span></a></li>
-        <li><a class="btn" href="https://music.apple.com/us/album/recovery-single/1824116381" target="_blank" rel="noopener" aria-label="Apple Music — RECOVERY — Apple Music">${ICONS.apple}<span class="btn-text"><span class="btn-title">Apple Music — RECOVERY</span><span class="btn-meta">Apple Music - Web Player</span></span></a></li>
-        <li><a class="btn" href="https://music.apple.com/us/song/time/1788721331" target="_blank" rel="noopener" aria-label="Apple Music — Time — Apple Music">${ICONS.apple}<span class="btn-text"><span class="btn-title">Apple Music — Time</span><span class="btn-meta">Apple Music - Web Player</span></span></a></li>
         <li><a class="btn" href="https://instagram.com/thinktwicefl" target="_blank" rel="noopener" aria-label="Instagram — Instagram">${ICONS.instagram}<span class="btn-text"><span class="btn-title">Instagram</span><span class="btn-meta">Instagram</span></span></a></li>
         <li><a class="btn" href="https://www.tiktok.com/@thinktwicefl" target="_blank" rel="noopener" aria-label="TikTok — TikTok">${ICONS.tiktok}<span class="btn-text"><span class="btn-title">TikTok</span><span class="btn-meta">TikTok</span></span></a></li>
-        <li><a class="btn" href="https://youtube.com/@thinktwicefl" target="_blank" rel="noopener" aria-label="YouTube — YouTube">${ICONS.youtube}<span class="btn-text"><span class="btn-title">YouTube</span><span class="btn-meta">YouTube</span></span></a></li>
       `;
     }
   </script>

--- a/links.json
+++ b/links.json
@@ -1,38 +1,14 @@
 // FILE: links.json
 {
-  "featured": [
-    {
-      "title": "RECOVERY — Stream",
-      "href": "https://found.ee/RECOVERY1",
-      "source": "found.ee",
-      "icon": "link"
-    },
-    {
-      "title": "TIME — Stream",
-      "href": "https://found.ee/time-10",
-      "source": "found.ee",
-      "icon": "link"
-    }
-  ],
-  "socials": [
-    {
-      "title": "Spotify (Artist)",
-      "href": "https://open.spotify.com/artist/0U2ZIIYIMFChatxKoQJdTU",
-      "source": "Spotify",
-      "icon": "spotify"
-    },
-    {
-      "title": "Apple Music — RECOVERY",
-      "href": "https://music.apple.com/us/album/recovery-single/1824116381",
-      "source": "Apple Music - Web Player",
-      "icon": "apple"
-    },
-    {
-      "title": "Apple Music — Time",
-      "href": "https://music.apple.com/us/song/time/1788721331",
-      "source": "Apple Music - Web Player",
-      "icon": "apple"
-    },
+    "featured": [
+      {
+        "title": "RECOVERY — Stream",
+        "href": "https://found.ee/RECOVERY1",
+        "source": "found.ee",
+        "icon": "link"
+      }
+    ],
+    "socials": [
     {
       "title": "Instagram",
       "href": "https://instagram.com/thinktwicefl",
@@ -44,12 +20,6 @@
       "href": "https://www.tiktok.com/@thinktwicefl",
       "source": "TikTok",
       "icon": "tiktok"
-    },
-    {
-      "title": "YouTube",
-      "href": "https://youtube.com/@thinktwicefl",
-      "source": "YouTube",
-      "icon": "youtube"
     },
     {
       "title": "Reddit post (press/promo link)",

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,25 @@
-// FILE: styles.css
+.band-header {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+.band-logo {
+  filter: drop-shadow(0 2px 12px #22d3ee88);
+  max-width: 220px;
+  height: auto;
+}
+:band-title {
+  font-family: 'Oswald', 'Impact', 'Arial Black', sans-serif;
+  font-size: 3rem;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  text-shadow: 0 2px 12px #0ea5e9cc, 0 1px 0 #111827;
+  font-weight: 900;
+  margin: 0;
+  text-transform: uppercase;
+}
 :root{
   --bg-0:#0b0b0f; --bg-1:#111827;
   --surface: rgba(255,255,255,.04);

--- a/styles.css
+++ b/styles.css
@@ -10,12 +10,11 @@
   max-width: 220px;
   height: auto;
 }
-:band-title {
+.band-title {
   font-family: 'Oswald', 'Impact', 'Arial Black', sans-serif;
   font-size: 3rem;
   letter-spacing: 0.08em;
   color: var(--accent);
-  text-shadow: 0 2px 12px #0ea5e9cc, 0 1px 0 #111827;
   font-weight: 900;
   margin: 0;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- remove incorrect streaming links and duplicate release entry
- update site metadata to say "Florida metal core"
- drop broken Spotify embed

## Testing
- `npm test` (fails: Could not read package.json)
- `npx prettier --check .`

------
https://chatgpt.com/codex/tasks/task_e_68ab83909fb88321bc396185ec9c07ff