### PR TITLE
Add default home route and Vercel rewrite config

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#0B0B0F] text-white">
+      <h1 className="text-2xl md:text-4xl font-bold">THINK TWICE — Coming Soon</h1>
+    </main>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,9 @@
         { "key": "Cache-Control", "value": "no-cache" }
       ]
     }
+  ],
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
   ]
 }
 


### PR DESCRIPTION
## Summary
- Add minimal `app/page.tsx` so `/` serves a placeholder home page
- Configure `vercel.json` rewrites so all paths resolve to `/`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx next build` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55068430832196fab226d339ebed