### PR TITLE
chore: simplify deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,1 +1,20 @@
+name: CI
 
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint

--- a/vercel.json
+++ b/vercel.json
@@ -34,9 +34,6 @@
         { "key": "Cache-Control", "value": "no-cache" }
       ]
     }
-  ],
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
   ]
 }
 


### PR DESCRIPTION
## Summary
- remove vercel CLI deployment step and run build/lint only
- drop global rewrite from `vercel.json` to avoid routing issues

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5700b3288321b6cf1ed1cb9dd882